### PR TITLE
AWSX to AWSX/Classic update & CLI Version Update addition for @pulumi/eks compatibility 

### DIFF
--- a/content/10_prerequisites/50_workshop_setup.md
+++ b/content/10_prerequisites/50_workshop_setup.md
@@ -136,7 +136,9 @@ $ kubectl version --client
 
 ## AWS Subscription and CLI
 
-At various points, you will use the AWS CLI to interact with infrastructure you've provisioned.
+At various points, you will use the AWS CLI to interact with infrastructure you've provisioned. Installation instructions are 
+[available here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), or are available for Linux below. As explained further on that page, the 
+CLI requires Python.
 
 
 ```bash

--- a/content/10_prerequisites/50_workshop_setup.md
+++ b/content/10_prerequisites/50_workshop_setup.md
@@ -131,15 +131,21 @@ Test to ensure the version you installed is up to date:
 ```bash
 $ kubectl version --client
 
-
 ```
 
 
 ## AWS Subscription and CLI
 
-At various points, you will use the AWS CLI to interact with infrastructure you've provisioned. Installation instructions are 
-[available here](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html). As explained further on that page, the 
-CLI requires Python.
+At various points, you will use the AWS CLI to interact with infrastructure you've provisioned.
+
+
+```bash
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+```
+
 
 > If you have multiple AWS accounts, you'll need to configure a profile for the account you're using in these labs. That process is 
 >[described here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). All Pulumi operations will respect your profile settings.

--- a/content/50_eks_platform/20_provision_cluster/10_configuring_aws.md
+++ b/content/50_eks_platform/20_provision_cluster/10_configuring_aws.md
@@ -23,7 +23,7 @@ Now that the AWS package is installed, we need to import it as part of our proje
 
 ```typescript
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as awsx from "@pulumi/awsx/classic";
 ```
 
 {{% notice info %}}
@@ -32,7 +32,7 @@ The `index.ts` file should now have the following contents:
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as awsx from "@pulumi/awsx/classic";
 ```
 
 ## Step 3 &mdash; Configure AWS

--- a/content/50_eks_platform/20_provision_cluster/20_create_cluster.md
+++ b/content/50_eks_platform/20_provision_cluster/20_create_cluster.md
@@ -44,7 +44,7 @@ The `index.ts` file should now have the following contents:
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as awsx from "@pulumi/awsx/classic";
 
 const name = 'lbriggs-workshop'
 const clusName = `${name}-cluster`
@@ -110,7 +110,7 @@ The `index.ts` file should now have the following contents:
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as awsx from "@pulumi/awsx/classic";
 import * as eks from "@pulumi/eks";
 
 const name = 'lbriggs-workshop'
@@ -255,7 +255,7 @@ The `index.ts` file should now have the following contents:
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
+import * as awsx from "@pulumi/awsx/classic";
 import * as eks from "@pulumi/eks";
 
 const name = 'lbriggs-workshop'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated Package import for awsx to awsx/classic to fix VPC creation variables, and added details for Updating AWS CLI to remedy an error with Cloud9's AWS CLI version not being recent enough to function properly with Pulumi's EKS package 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
