### PR TITLE
Fix stack output name

### DIFF
--- a/content/20_intro_modern_iac_ts/20_getting_started_with_pulumi/30_updating_infrastructure.md
+++ b/content/20_intro_modern_iac_ts/20_getting_started_with_pulumi/30_updating_infrastructure.md
@@ -195,7 +195,7 @@ pulumi up
 Now you can view the contents of your website!
 
 ```bash
-$ curl $(pulumi stack output websiteUrl)
+$ curl $(pulumi stack output url)
 
 <html>
 

--- a/content/25_intro_modern_iac_python/20_getting_started_with_pulumi/30_updating_infrastructure.md
+++ b/content/25_intro_modern_iac_python/20_getting_started_with_pulumi/30_updating_infrastructure.md
@@ -206,7 +206,7 @@ pulumi up
 Now you can view the contents of your website!
 
 ```bash
-$ curl $(pulumi stack output websiteUrl)
+$ curl $(pulumi stack output url)
 
 <html>
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
In #32 the name of the stack output of the s3 website url was updated in the pulumi code, in both the Typescript and Python versions. This PR updates the name of the stack output in the curl command in the instructions to match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
